### PR TITLE
this refines the Matrix import to only import SparseMatrix

### DIFF
--- a/BayesNSGP/DESCRIPTION
+++ b/BayesNSGP/DESCRIPTION
@@ -1,12 +1,20 @@
 Package: BayesNSGP
 Title: Bayesian Analysis of Non-Stationary Gaussian Process Models
 Description: Enables off-the-shelf functionality for fully Bayesian, nonstationary Gaussian process modeling. The approach to nonstationary modeling involves a closed-form, convolution-based covariance function with spatially-varying parameters; these parameter processes can be specified either deterministically (using covariates or basis functions) or stochastically (using approximate Gaussian processes). Stationary Gaussian processes are a special case of our methodology, and we furthermore implement approximate Gaussian process inference to account for very large spatial data sets (Finley, et al (2017) <arXiv:1702.00434v2>). Bayesian inference is carried out using Markov chain Monte Carlo methods via the 'nimble' package, and posterior prediction for the Gaussian process at unobserved locations is provided as a post-processing step.
-Version: 0.2
-Date: 2024-02-28
+Version: 0.2.0
+Date: 2025-12-11
 Maintainer: Daniel Turek <danielturek@gmail.com>
-Author: Daniel Turek, Mark Risser
+Authors@R: c(
+    person(given = "Daniel",
+           family = "Turek",
+           role = c("aut", "cre"),
+           email = "danielturek@gmail.com"),
+    person(given = "Mark",
+           family = "Risser",
+           role = "aut")
+    )
 Depends: R (>= 3.4.0),nimble
 Imports: FNN,Matrix,methods,StatMatch
 License: GPL-3
 Encoding: UTF-8
-RoxygenNote: 7.1.2
+RoxygenNote: 7.3.2

--- a/BayesNSGP/DESCRIPTION
+++ b/BayesNSGP/DESCRIPTION
@@ -2,16 +2,16 @@ Package: BayesNSGP
 Title: Bayesian Analysis of Non-Stationary Gaussian Process Models
 Description: Enables off-the-shelf functionality for fully Bayesian, nonstationary Gaussian process modeling. The approach to nonstationary modeling involves a closed-form, convolution-based covariance function with spatially-varying parameters; these parameter processes can be specified either deterministically (using covariates or basis functions) or stochastically (using approximate Gaussian processes). Stationary Gaussian processes are a special case of our methodology, and we furthermore implement approximate Gaussian process inference to account for very large spatial data sets (Finley, et al (2017) <arXiv:1702.00434v2>). Bayesian inference is carried out using Markov chain Monte Carlo methods via the 'nimble' package, and posterior prediction for the Gaussian process at unobserved locations is provided as a post-processing step.
 Version: 0.2.0
-Date: 2025-12-11
+Date: 2025-12-10
 Maintainer: Daniel Turek <danielturek@gmail.com>
 Authors@R: c(
-    person(given = "Daniel",
-           family = "Turek",
-           role = c("aut", "cre"),
-           email = "danielturek@gmail.com"),
-    person(given = "Mark",
-           family = "Risser",
-           role = "aut")
+    person(given = 'Daniel',
+           family = 'Turek',
+           role = c('aut', 'cre'),
+           email = 'danielturek@gmail.com'),
+    person(given = 'Mark',
+           family = 'Risser',
+           role = 'aut')
     )
 Depends: R (>= 3.4.0),nimble
 Imports: FNN,Matrix,methods,StatMatch

--- a/BayesNSGP/NAMESPACE
+++ b/BayesNSGP/NAMESPACE
@@ -1,8 +1,8 @@
-importFrom("stats", "dist", "rnorm")
+importFrom('stats', 'dist', 'rnorm')
 import(methods)
 import(nimble)
 import(FNN)
-importFrom("Matrix", "sparseMatrix")
+importFrom('Matrix', 'sparseMatrix')
 import(StatMatch)
 
 export(Cy_sm)

--- a/BayesNSGP/NAMESPACE
+++ b/BayesNSGP/NAMESPACE
@@ -2,7 +2,7 @@ importFrom("stats", "dist", "rnorm")
 import(methods)
 import(nimble)
 import(FNN)
-import(Matrix)
+importFrom("Matrix", "sparseMatrix")
 import(StatMatch)
 
 export(Cy_sm)

--- a/BayesNSGP/R/gp2Scale.R
+++ b/BayesNSGP/R/gp2Scale.R
@@ -42,9 +42,9 @@
 #' @param cstat_opt Scalar; determines the compactly supported kernel. See Details.
 #' @param normalize Logical; should C_sparse have 1's along the diagonal
 #' @param bumpLocs Array of bump function locations (n2*d x n1)
-#' @param rads Matrix of bump function radii (n1 x n2; denoted r_{ij})
-#' @param ampls Matrix of bump function amplitudes (n1 x n2; denoted a_{ij})
-#' @param shps Matrix of bump function shape parameters (n1 x n2; denoted b_{ij})
+#' @param rads Matrix of bump function radii (n1 x n2; denoted \eqn{r_{ij}})
+#' @param ampls Matrix of bump function amplitudes (n1 x n2; denoted \eqn{a_{ij}})
+#' @param shps Matrix of bump function shape parameters (n1 x n2; denoted \eqn{b_{ij}})
 #' @param dist1_sq N x N matrix; contains values of pairwise squared distances
 #' in the x-coordinate.
 #' @param dist2_sq N x N matrix; contains values of pairwise squared distances
@@ -650,9 +650,9 @@ Cy_dm <- nimbleFunction(  # Generate the sparse kernel in dense format
 #' @param r0 Scalar; length-scale of sparse stationary kernel.
 #' @param cstat_opt Scalar; determines the compactly supported kernel. See Details.
 #' @param bumpLocs Array of bump function locations (n2*d x n1)
-#' @param rads Matrix of bump function radii (n1 x n2; denoted r_{ij})
-#' @param ampls Matrix of bump function amplitudes (n1 x n2; denoted a_{ij})
-#' @param shps Matrix of bump function shape parameters (n1 x n2; denoted b_{ij})
+#' @param rads Matrix of bump function radii (n1 x n2; denoted \eqn{r_{ij}})
+#' @param ampls Matrix of bump function amplitudes (n1 x n2; denoted \eqn{a_{ij}})
+#' @param shps Matrix of bump function shape parameters (n1 x n2; denoted \eqn{b_{ij}})
 #' @param dist1_sq N x N matrix; contains values of pairwise squared distances
 #' in the x-coordinate.
 #' @param dist2_sq N x N matrix; contains values of pairwise squared distances

--- a/BayesNSGP/man/Cy_sm.Rd
+++ b/BayesNSGP/man/Cy_sm.Rd
@@ -53,11 +53,11 @@ Cy_sm(
 
 \item{bumpLocs}{Array of bump function locations (n2*d x n1)}
 
-\item{rads}{Matrix of bump function radii (n1 x n2; denoted r_{ij})}
+\item{rads}{Matrix of bump function radii (n1 x n2; denoted \eqn{r_{ij}})}
 
-\item{ampls}{Matrix of bump function amplitudes (n1 x n2; denoted a_{ij})}
+\item{ampls}{Matrix of bump function amplitudes (n1 x n2; denoted \eqn{a_{ij}})}
 
-\item{shps}{Matrix of bump function shape parameters (n1 x n2; denoted b_{ij})}
+\item{shps}{Matrix of bump function shape parameters (n1 x n2; denoted \eqn{b_{ij}})}
 
 \item{dist1_sq}{N x N matrix; contains values of pairwise squared distances
 in the x-coordinate.}

--- a/BayesNSGP/man/crossCy_sm.Rd
+++ b/BayesNSGP/man/crossCy_sm.Rd
@@ -48,11 +48,11 @@ crossCy_sm(
 
 \item{bumpLocs}{Array of bump function locations (n2*d x n1)}
 
-\item{rads}{Matrix of bump function radii (n1 x n2; denoted r_{ij})}
+\item{rads}{Matrix of bump function radii (n1 x n2; denoted \eqn{r_{ij}})}
 
-\item{ampls}{Matrix of bump function amplitudes (n1 x n2; denoted a_{ij})}
+\item{ampls}{Matrix of bump function amplitudes (n1 x n2; denoted \eqn{a_{ij}})}
 
-\item{shps}{Matrix of bump function shape parameters (n1 x n2; denoted b_{ij})}
+\item{shps}{Matrix of bump function shape parameters (n1 x n2; denoted \eqn{b_{ij}})}
 
 \item{Sigma11}{Vector of length N; contains the 1-1 element of the 
 anisotropy process for each station.}

--- a/makePackage.R
+++ b/makePackage.R
@@ -19,7 +19,7 @@ namespaceFilename <- paste0(baseDir, 'BayesNSGP/NAMESPACE')
 namespace <- readLines(namespaceFilename)
 if(length(namespace) >= 2) namespace <- namespace[2:length(namespace)]
 namespace <- c('import(StatMatch)', namespace)
-namespace <- c('import(Matrix)', namespace)
+namespace <- c('importFrom("Matrix", "sparseMatrix")', namespace)
 namespace <- c('import(FNN)', namespace)
 namespace <- c('import(nimble)', namespace)
 namespace <- c('import(methods)', namespace)


### PR DESCRIPTION
If this is not done, then `import(nimble)` and `import(Matrix)` both now import `expm` now that we are adding `expm` to `nimble`. This triggers a warning on R CMD check (and on loading the package).

I also fixed a couple things flagged by R CMD check. But there are a few other things you'll need to deal with @danielturek .